### PR TITLE
fix: strictly serialize API responses to match Zod schemas

### DIFF
--- a/server/routes/categories.ts
+++ b/server/routes/categories.ts
@@ -16,7 +16,7 @@ export default async function categoryRoutes(fastify: FastifyInstance) {
             tags: ['categories'],
             response: {
                 200: z.array(z.object({
-                    _id: z.preprocess((val: any) => val?.toString(), z.string()).describe('Unique identifier for the category'),
+                    _id: z.string().describe('Unique identifier for the category'),
                     name: z.string().describe('Display name of the category'),
                     description: z.string().optional().describe('Optional descriptive text'),
                     icon: z.string().describe('Lucide icon name (e.g., "Globe", "Briefcase")'),
@@ -27,7 +27,10 @@ export default async function categoryRoutes(fastify: FastifyInstance) {
         }
     }, async (_req, _reply) => {
         const categories = await CategoryModel.find().sort({ order: 1, name: 1 });
-        return categories;
+        return categories.map(c => ({
+            ...c.toObject(),
+            _id: c._id.toString()
+        }));
     });
 
     // POST create category
@@ -45,7 +48,7 @@ export default async function categoryRoutes(fastify: FastifyInstance) {
             }),
             response: {
                 200: z.object({
-                    _id: z.preprocess((val: any) => val?.toString(), z.string()),
+                    _id: z.string(),
                     name: z.string(),
                     description: z.string().optional(),
                     icon: z.string(),
@@ -57,7 +60,10 @@ export default async function categoryRoutes(fastify: FastifyInstance) {
     }, async (req, _reply) => {
         const category = new CategoryModel(req.body);
         await category.save();
-        return category;
+        return {
+            ...category.toObject(),
+            _id: category._id.toString()
+        };
     });
 
     // PUT update category
@@ -78,7 +84,7 @@ export default async function categoryRoutes(fastify: FastifyInstance) {
             }),
             response: {
                 200: z.object({
-                    _id: z.preprocess((val: any) => val?.toString(), z.string()),
+                    _id: z.string(),
                     name: z.string(),
                     description: z.string().optional(),
                     icon: z.string(),
@@ -97,7 +103,10 @@ export default async function categoryRoutes(fastify: FastifyInstance) {
             { new: true }
         );
         if (!category) return reply.status(404).send({ error: 'Category not found' });
-        return category;
+        return {
+            ...category.toObject(),
+            _id: category._id.toString()
+        };
     });
 
     // DELETE category (unassigns URLs, does not delete them)

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -201,7 +201,7 @@ export default async function scanRoutes(fastify: FastifyInstance) {
             }),
             response: {
                 200: z.array(z.object({
-                    _id: z.preprocess((val: any) => val?.toString(), z.string()).describe('Scan ID'),
+                    _id: z.string().describe('Scan ID'),
                     timestamp: z.any().describe('When the scan was performed'),
                     issuesCount: z.number().describe('Total number of issues found across all steps'),
                     documentTitle: z.string().nullable().optional().describe('HTML document title captured during scan'),
@@ -219,7 +219,7 @@ export default async function scanRoutes(fastify: FastifyInstance) {
                 : (s.issues?.length || 0);
                 
             return {
-                _id: s._id,
+                _id: s._id.toString(),
                 timestamp: s.timestamp,
                 issuesCount: totalIssues,
                 documentTitle: s.documentTitle,
@@ -240,7 +240,7 @@ export default async function scanRoutes(fastify: FastifyInstance) {
             }),
             response: {
                 200: z.object({
-                    _id: z.preprocess((val: any) => val?.toString(), z.string()),
+                    _id: z.string(),
                     timestamp: z.any(),
                     issues: z.array(z.unknown()),
                     documentTitle: z.string().nullable().optional(),
@@ -256,7 +256,11 @@ export default async function scanRoutes(fastify: FastifyInstance) {
         const { id } = req.params;
         const scan = await ScanModel.findOne({ urlId: id }).sort({ timestamp: -1 });
         if (!scan) return null;
-        return scan;
+        return {
+            ...scan.toObject(),
+            _id: scan._id.toString(),
+            urlId: scan.urlId?.toString()
+        };
     });
 
     // READ: Get a specific scan by scan ID
@@ -270,8 +274,8 @@ export default async function scanRoutes(fastify: FastifyInstance) {
             }),
             response: {
                 200: z.object({
-                    _id: z.preprocess((val: any) => val?.toString(), z.string()),
-                    urlId: z.preprocess((val: any) => val?.toString(), z.string()).describe('The parent URL ID'),
+                    _id: z.string(),
+                    urlId: z.string().describe('The parent URL ID'),
                     timestamp: z.any(),
                     issues: z.array(z.unknown()).describe('Primary issues list (legacy/last step)'),
                     documentTitle: z.string().nullable().optional(),
@@ -290,7 +294,11 @@ export default async function scanRoutes(fastify: FastifyInstance) {
         const { scanId } = req.params;
         const scan = await ScanModel.findById(scanId);
         if (!scan) return null;
-        return scan;
+        return {
+            ...scan.toObject(),
+            _id: scan._id.toString(),
+            urlId: scan.urlId?.toString()
+        };
     });
 
     // ACTION: Export Scan as PDF

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -15,7 +15,7 @@ export default async function settingsRoutes(fastify: FastifyInstance) {
             tags: ['settings'],
             response: {
                 200: z.object({
-                    _id: z.preprocess((val: any) => val?.toString(), z.string()),
+                    _id: z.string(),
                     runners: z.array(z.string()).describe('Default accessibility runners (axe, htmlcs)'),
                     includeNotices: z.boolean().describe('Include Pa11y notices in results'),
                     includeWarnings: z.boolean().describe('Include Pa11y warnings in results'),
@@ -39,6 +39,7 @@ export default async function settingsRoutes(fastify: FastifyInstance) {
         const settings = await getSettings();
         return {
             ...settings.toObject(),
+            _id: settings._id.toString(),
             headers: Object.fromEntries(settings.headers || new Map())
         };
     });
@@ -52,7 +53,7 @@ export default async function settingsRoutes(fastify: FastifyInstance) {
             body: settingsSchema,
             response: {
                 200: z.object({
-                    _id: z.preprocess((val: any) => val?.toString(), z.string()),
+                    _id: z.string(),
                     runners: z.array(z.string()),
                     includeNotices: z.boolean(),
                     includeWarnings: z.boolean(),
@@ -83,6 +84,7 @@ export default async function settingsRoutes(fastify: FastifyInstance) {
         }
         return {
             ...settings.toObject(),
+            _id: settings._id.toString(),
             headers: Object.fromEntries(settings.headers || new Map())
         };
     });

--- a/server/routes/urls.ts
+++ b/server/routes/urls.ts
@@ -24,12 +24,33 @@ export default async function urlRoutes(fastify: FastifyInstance) {
             summary: 'List all URLs',
             tags: ['urls'],
             response: {
-                200: z.any()
+                200: z.array(z.object({
+                    _id: z.string().describe('Unique identifier for the URL'),
+                    url: z.string().describe('The destination URL being monitored'),
+                    name: z.string().nullable().optional().describe('Human-readable name for the URL'),
+                    schedule: z.string().nullable().optional().describe('Cron-style schedule string (empty for manual)'),
+                    standard: z.string().nullable().optional().describe('Accessibility standard (e.g., WCAG22AA)'),
+                    status: z.string().nullable().optional().describe('Current status of the URL monitoring'),
+                    lastScanAt: z.any().optional().describe('Timestamp of the most recent completed scan'),
+                    lastIssueCount: z.number().nullable().optional().describe('Number of accessibility issues found in the last scan'),
+                    lastScore: z.number().nullable().optional().describe('Overall accessibility score from the last scan (0-100)'),
+                    lastThumbnail: z.string().nullable().optional().describe('Relative path to the last scan thumbnail'),
+                    lastScreenshot: z.string().nullable().optional().describe('Relative path to the last scan full screenshot'),
+                    actions: z.array(z.any()).optional().describe('List of multi-step interactive actions to perform before scanning'),
+                    overrides: overridesSchema,
+                    categoryId: z.string().nullable().optional().describe('Optional ID of the assigned category'),
+                    createdAt: z.any().optional(),
+                    updatedAt: z.any().optional()
+                }))
             }
         }
     }, async (_req, _reply) => {
         const urls = await UrlModel.find().sort({ createdAt: -1 });
-        return urls;
+        return urls.map(u => ({
+            ...u.toObject(),
+            _id: u._id.toString(),
+            categoryId: u.categoryId?.toString() || null
+        }));
     });
 
     // CRUD: Add URL
@@ -58,7 +79,7 @@ export default async function urlRoutes(fastify: FastifyInstance) {
             }),
             response: {
                 200: z.object({
-                    _id: z.preprocess((val: any) => val?.toString(), z.string()),
+                    _id: z.string(),
                     url: z.string(),
                     name: z.string().optional(),
                     schedule: z.string(),
@@ -96,7 +117,10 @@ export default async function urlRoutes(fastify: FastifyInstance) {
         const { scanQueue } = await import('../lib/scheduler.js');
         scanQueue.enqueue(newUrl._id.toString(), true);
 
-        return newUrl;
+        return {
+            ...newUrl.toObject(),
+            _id: newUrl._id.toString()
+        };
     });
 
     // CRUD: Delete URL
@@ -152,7 +176,7 @@ export default async function urlRoutes(fastify: FastifyInstance) {
             }),
             response: {
                 200: z.object({
-                    _id: z.preprocess((val: any) => val?.toString(), z.string()),
+                    _id: z.string(),
                     url: z.string(),
                     name: z.string().optional(),
                     schedule: z.string(),
@@ -173,6 +197,9 @@ export default async function urlRoutes(fastify: FastifyInstance) {
         const { id } = req.params;
         const updated = await UrlModel.findByIdAndUpdate(id, req.body, { new: true });
         if (!updated) return reply.status(404).send({ error: 'Not found', message: `URL with ID ${id} not found` });
-        return updated;
+        return {
+            ...updated.toObject(),
+            _id: updated._id.toString()
+        };
     });
 }


### PR DESCRIPTION
This PR fixes the `FST_ERR_RESPONSE_SERIALIZATION` (500 Internal Server Error) crashes that occurred in production after the introduction of strict Zod schemas for Swagger documentation.

**Root Cause:**
Fastify converts Zod response schemas into strict JSON Schemas via `zod-to-json-schema`. However, Zod's `z.preprocess()` logic is ignored during this conversion. When Fastify's fast-json-stringify encountered complex Mongoose objects (like `ObjectId` or `Map`) where it expected primitive strings (as defined by the schemas), it threw a serialization error to prevent data leakage.

**Fixes:**
1. Removed all `z.preprocess` hacks from the response schemas and restored strict type constraints (`z.string()`).
2. Updated all route handlers (`urls.ts`, `scans.ts`, `categories.ts`, `settings.ts`) to explicitly format their outputs. Mongoose documents are now converted via `.toObject()` and any `ObjectId`s are safely stringified via `.toString()` before being returned to Fastify.

This ensures the data returned by the handlers perfectly matches the defined OpenAPI documentation, ensuring stability and type safety without sacrificing Swagger UI compatibility.